### PR TITLE
Update backport support in Wheezy for LXC 1.0.5

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -8,13 +8,15 @@ dependencies:
   - role: debops.backporter
     backporter_package: 'lxc'
     backporter_version: '1.0'
-    backporter_source_version: '1.0.4-3'
-    backporter_install_packages: [ 'lxc_*.deb', 'lxc-stuff_*.deb' ]
+    backporter_source_version: '1.0.5-3'
+    backporter_command_dget: 'dget --allow-unauthenticated'
+    backporter_install_prerequisites: [ 'init-system-helpers' ]
+    backporter_install_packages: [ 'lxc_*.deb' ]
     backporter_upload_packages: [ 'lxc*.deb' ]
     backporter_prerequisites: [ 'dh-autoreconf', 'doxygen', 'docbook2x',
                                 'graphviz', 'libapparmor-dev', 'liblua5.2-dev',
                                 'libseccomp-dev', 'libselinux1-dev',
-                                'pkg-config', 'python3-dev' ]
+                                'pkg-config', 'python3-dev', 'dh-systemd' ]
 
 galaxy_info:
   author: 'Maciej Delmanowski'

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -2,7 +2,7 @@
 
 # List of packages to install on different distributions
 lxc_distribution_packages:
-  Debian_wheezy: [ 'debootstrap', 'python3', 'lxc', 'lxc-stuff' ]
+  Debian_wheezy: [ 'debootstrap', 'python3', 'lxc', 'init-system-helpers' ]
   Ubuntu_trusty: [ 'debootstrap', 'python3', 'lxc', 'lxc-templates', 'libcgmanager0' ]
 
 # Notification message about new of updated LXC kernel


### PR DESCRIPTION
This patch brings modifications to support LXC 1.0.5 package backported
from Debian Jessie to Debian Wheezy. Ubuntu hosts should be unaffected.

List of changes in the Jessie package can be found at:
http://metadata.ftp-master.debian.org/changelogs/main/l/lxc/testing_changelog
