### PR TITLE
Fix error when admin in LXC containers is disabled

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -86,7 +86,7 @@ lxc_template_admin_name: '{{ ansible_ssh_user if ansible_ssh_user != "root" else
 lxc_template_admin_gecos: 'System Administrator'
 
 # Home directory for administrator account
-lxc_template_admin_home: '{{ "/home/" + lxc_template_admin_name }}'
+lxc_template_admin_home: '{{ ("/home/" + lxc_template_admin_name) if lxc_template_admin_name else "/home/" + lookup("env","USER") }}'
 
 # Should the admin account be created as system account (UID/GID below <1000)?
 lxc_template_admin_system: False


### PR DESCRIPTION
When 'lxc_template_admin_name' was disabled by setting it as False,
Ansible would emit an error about joining string and bool values. So
instead, make sure that a string value is always present in
'lxc_template_admin_home'. It shouldn't ever be used, but just in case,
make it a legit one, as well.