### PR TITLE
add required mount point configuration for systemd

### DIFF
--- a/templates/etc/lxc/lxc.conf.j2
+++ b/templates/etc/lxc/lxc.conf.j2
@@ -5,3 +5,8 @@
 # Default path to LXC containers
 lxc.lxcpath = {{ lxc_root_path }}
 
+{% if (ansible_distribution == 'Debian' and
+       ansible_distribution_release == 'jessie') %}
+# Use all cgroup controllers in the containers
+lxc.cgroup.use = @all
+{% endif %}

--- a/templates/usr/share/lxc/config/debian.jessie.conf.j2
+++ b/templates/usr/share/lxc/config/debian.jessie.conf.j2
@@ -1,0 +1,10 @@
+# {{ ansible_managed }}
+
+# Prepare file systems for systemd
+lxc.mount.auto = cgroup:mixed
+lxc.mount.entry = tmpfs dev/shm tmpfs rw,nosuid,nodev,create=dir 0 0
+lxc.mount.entry = tmpfs run tmpfs rw,nosuid,nodev,mode=755,create=dir 0 0
+lxc.mount.entry = tmpfs run/lock tmpfs rw,nosuid,nodev,noexec,relatime,size=5120k,create=dir 0 0
+lxc.mount.entry = debugfs sys/kernel/debug debugfs rw,relatime 0 0
+lxc.mount.entry = mqueue dev/mqueue mqueue rw,relatime,create=dir 0 0
+lxc.mount.entry = hugetlbfs dev/hugepages hugetlbfs rw,relatime,create=dir 0 0


### PR DESCRIPTION
  if cap_sys_admin is dropped in a jessie container with
  systemd, the startup fails as systemd is not allowed to
  mount the necessary file systems.