### PR TITLE
Redesign admin account in new LXC containers

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,3 +12,6 @@ v0.1.0
   required by newer Linux kernel packages, also backported from Jessie.
   [drybjed]
 
+- Allow setting default OS release created by the ``lxc-debops`` template.
+  By default the host release will be used as the container release. [drybjed]
+

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -26,3 +26,8 @@ v0.1.0
   created if not present. Administrator account will be added to all specified
   system groups. [drybjed]
 
+- Modify ``sudo`` configuration to specify the name of the group that is
+  configured to have passwordless access to all commands. By default first
+  group specified in ``lxc_template_admin_groups`` will be granted full access.
+  [drybjed]
+

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,3 +15,10 @@ v0.1.0
 - Allow setting default OS release created by the ``lxc-debops`` template.
   By default the host release will be used as the container release. [drybjed]
 
+- Redesign admin account and SSH key configuration in new LXC containers.
+
+  Admin account can now be enabled or disabled using separate
+  ``lxc_template_admin`` variable. By default, a system account will be created
+  (with UID < 1000) with home in ``/var/local/`` directory to avoid clashes
+  with ``/home`` directories. You can also specify default shell. [drybjed]
+

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,3 +22,7 @@ v0.1.0
   (with UID < 1000) with home in ``/var/local/`` directory to avoid clashes
   with ``/home`` directories. You can also specify default shell. [drybjed]
 
+- Switch from creation of 1 system group to a list of system groups that are
+  created if not present. Administrator account will be added to all specified
+  system groups. [drybjed]
+

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -54,7 +54,7 @@ lxc_template_admin_name: '{{ ansible_ssh_user if ansible_ssh_user != "root" else
 
 # Admin account will have its own group, here you can specify a system group
 # which will be created for administrative access through 'sudo'
-lxc_template_admin_group: 'admins'
+lxc_template_admin_groups: [ 'admins', 'staff', 'adm' ]
 
 # Home directory for administrator account (normal)
 lxc_template_admin_home: '{{ "/home/" + lxc_template_admin_name }}'

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -68,8 +68,11 @@ lxc_template_admin_comment: 'System Administrator'
 # Default shell set on the admin account
 lxc_template_admin_shell: '/bin/bash'
 
-# Configure sudo access for the default admin group
-lxc_template_admin_sudo: True
+# Configure paswordless sudo access for selected accounts
+lxc_template_sudo: True
+
+# A group which grants passwordless sudo access
+lxc_template_sudo_group: '{{ lxc_template_admin_groups[0] | default("") }}'
 
 # SSH public key to put in administrator account of new container
 lxc_template_admin_sshkeys: [ '{{ lookup("pipe", "ssh-add -L || cat ~/.ssh/id_rsa.pub || true") }}' ]

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -43,24 +43,36 @@ lxc_capabilities_drop: [ 'mknod', 'sys_admin', 'sys_rawio', 'syslog', 'wake_alar
 # Mark new containers to be started automatically after reboot
 lxc_template_autostart: True
 
-# Name of administrator account to create (by default, your username)
-lxc_template_admin_name: '{{ ansible_ssh_user if ansible_ssh_user != "root" else lookup("env","USER") }}'
-
-# GECOS comment which will be set on the admin account
-lxc_template_admin_gecos: 'System Administrator'
-
-# Home directory for administrator account
-lxc_template_admin_home: '{{ ("/home/" + lxc_template_admin_name) if lxc_template_admin_name else "/home/" + lookup("env","USER") }}'
+# Enable or disable creation of an administrator account
+lxc_template_admin: True
 
 # Should the admin account be created as system account (UID/GID below <1000)?
-lxc_template_admin_system: False
+lxc_template_admin_system: True
+
+# Name of administrator account to create (by default, your username)
+lxc_template_admin_name: '{{ ansible_ssh_user if ansible_ssh_user != "root" else lookup("env","USER") }}'
 
 # Admin account will have its own group, here you can specify a system group
 # which will be created for administrative access through 'sudo'
 lxc_template_admin_group: 'admins'
 
+# Home directory for administrator account (normal)
+lxc_template_admin_home: '{{ "/home/" + lxc_template_admin_name }}'
+
+# Home directory for administrator account (system)
+lxc_template_admin_system_home: '{{ ansible_local.root.home + "/" + lxc_template_admin_name }}'
+
+# GECOS comment which will be set on the admin account
+lxc_template_admin_comment: 'System Administrator'
+
+# Default shell set on the admin account
+lxc_template_admin_shell: '/bin/bash'
+
+# Configure sudo access for the default admin group
+lxc_template_admin_sudo: True
+
 # SSH public key to put in administrator account of new container
-lxc_template_admin_sshkeys: [ '{{ lookup("pipe", "ssh-add -L") }}' ]
+lxc_template_admin_sshkeys: [ '{{ lookup("pipe", "ssh-add -L || cat ~/.ssh/id_rsa.pub || true") }}' ]
 
 # Address of Debian mirror to use in debootstrap
 # Example usage with local apt-cacher-ng proxy: 'http://cache.{{ ansible_domain }}:3142/debian'

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -66,6 +66,9 @@ lxc_template_admin_sshkeys: [ '{{ lookup("pipe", "ssh-add -L") }}' ]
 # Example usage with local apt-cacher-ng proxy: 'http://cache.{{ ansible_domain }}:3142/debian'
 lxc_template_debootstrap_mirror: 'http://http.debian.net/debian'
 
+# Default release installed by debootstrap if no release was specified
+lxc_template_debootstrap_release: '{{ ansible_distribution_release }}'
+
 # Automatically add 'security.debian.org' repository and perform 'apt-get
 # upgrade' on container creation to get latest security updates. Container
 # creation takes longer, but resulting system is more secure.

--- a/templates/usr/share/lxc/templates/lxc-debops.j2
+++ b/templates/usr/share/lxc/templates/lxc-debops.j2
@@ -89,31 +89,54 @@ EOF
 {% endif %}
 
 {% endif %}
-{% if lxc_template_admin_name is defined and lxc_template_admin_name %}
-    # Configure admin account
-    chroot $rootfs adduser --disabled-password --home {{ lxc_template_admin_home }}{% if lxc_template_admin_system|d() and lxc_template_admin_system %} --system{% endif %} --gecos "{{ lxc_template_admin_gecos }}" {{ lxc_template_admin_name }}
+{% if lxc_template_admin is defined and lxc_template_admin %}
+    lxc_template_admin_name="{{ lxc_template_admin_name }}"
+    lxc_template_admin_group="{{ lxc_template_admin_group }}"
+    lxc_template_admin_comment="{{ lxc_template_admin_comment }}"
+    lxc_template_admin_shell="{{ lxc_template_admin_shell }}"
+{% if lxc_template_admin_system is defined and lxc_template_admin_system %}
+    lxc_template_admin_home="{{ lxc_template_admin_system_home }}"
+{% else %}
+    lxc_template_admin_home="{{ lxc_template_admin_home }}"
+{% endif %}
 
-{% if lxc_template_admin_group is defined and lxc_template_admin_group %}
-    # Configure admin group
-    touch $rootfs/etc/sudoers.d/{{ lxc_template_admin_group }}
-    chroot $rootfs addgroup --system {{ lxc_template_admin_group }}
-    echo "%{{ lxc_template_admin_group }} ALL = (ALL:ALL) NOPASSWD: SETENV: ALL" > $rootfs/etc/sudoers.d/{{ lxc_template_admin_group }}
-    chroot $rootfs chmod 440 /etc/sudoers.d/{{ lxc_template_admin_group }}
-    chroot $rootfs adduser {{ lxc_template_admin_name }} {{ lxc_template_admin_group }}
+    # Create admin system group
+    chroot $rootfs getent group ${lxc_template_admin_group} || chroot $rootfs groupadd --system ${lxc_template_admin_group}
+
+{% if lxc_template_admin_sudo is defined and lxc_template_admin_sudo %}
+    # Configure admin group in sudo
+    echo "%${lxc_template_admin_group} ALL = (ALL:ALL) NOPASSWD: SETENV: ALL" > $rootfs/etc/sudoers.d/${lxc_template_admin_group}
+    chroot $rootfs chmod 0440 /etc/sudoers.d/${lxc_template_admin_group}
+
+{% endif %}
+    # Create administrator account
+{% if lxc_template_admin_system is defined and lxc_template_admin_system %}
+    chroot $rootfs getent passwd ${lxc_template_admin_name} || chroot $rootfs useradd --system --user-group --groups ${lxc_template_admin_group} --create-home --home ${lxc_template_admin_home} --comment "${lxc_template_admin_comment}" --shell ${lxc_template_admin_shell} ${lxc_template_admin_name}
+{% else %}
+    chroot $rootfs getent passwd ${lxc_template_admin_name} || chroot $rootfs adduser --disabled-password --home ${lxc_template_admin_home} --gecos "${lxc_template_admin_comment}" --shell ${lxc_template_admin_shell} ${lxc_template_admin_name}
+    chroot $rootfs adduser ${lxc_template_admin_name} ${lxc_template_admin_group}
+{% endif %}
 
 {% endif %}
 {% if lxc_template_admin_sshkeys is defined and lxc_template_admin_sshkeys %}
-    # Add SSH keys to admin account
-    chroot $rootfs mkdir -m 700 {{ lxc_template_admin_home }}/.ssh
-    echo "{{ lxc_template_admin_sshkeys | join('\n') }}" > $rootfs{{ lxc_template_admin_home }}/.ssh/authorized_keys
-    chroot $rootfs chown -R {{ lxc_template_admin_name }}:{{ lxc_template_admin_name }} {{ lxc_template_admin_home }}/.ssh
+    lxc_template_admin_sshkeys="{{ lxc_template_admin_sshkeys|d([]) | join('\n') }}"
+{% else %}
+    lxc_template_admin_sshkeys=""
+{% endif %}
 
-    # Add SSH keys to root account
-    mkdir -m 700 $rootfs/root/.ssh
-    echo "{{ lxc_template_admin_sshkeys | join('\n') }}" > $rootfs/root/.ssh/authorized_keys
+    if [ -n "${lxc_template_admin_sshkeys}" ] ; then
+
+        chroot $rootfs mkdir -p -m 700 /root/.ssh
+        echo "${lxc_template_admin_sshkeys}" > $rootfs/root/.ssh/authorized_keys
+
+{% if lxc_template_admin is defined and lxc_template_admin %}
+        chroot $rootfs mkdir -p -m 700 ${lxc_template_admin_home}/.ssh
+        echo "${lxc_template_admin_sshkeys}" > ${rootfs}${lxc_template_admin_home}/.ssh/authorized_keys
+        chroot $rootfs chown -R ${lxc_template_admin_name}:${lxc_template_admin_name} ${lxc_template_admin_home}/.ssh
 
 {% endif %}
-{% endif %}
+    fi
+
 {% if lxc_hidepid is defined and lxc_hidepid %}
     # Create system group for /proc access
     chroot $rootfs addgroup --system {{ lxc_hidepid_group }}

--- a/templates/usr/share/lxc/templates/lxc-debops.j2
+++ b/templates/usr/share/lxc/templates/lxc-debops.j2
@@ -91,7 +91,8 @@ EOF
 {% endif %}
 {% if lxc_template_admin is defined and lxc_template_admin %}
     lxc_template_admin_name="{{ lxc_template_admin_name }}"
-    lxc_template_admin_group="{{ lxc_template_admin_group }}"
+    lxc_template_admin_groups=( {{ lxc_template_admin_groups | join(' ') }} )
+    lxc_template_admin_groups_useradd="{{ lxc_template_admin_groups | join(',') }}"
     lxc_template_admin_comment="{{ lxc_template_admin_comment }}"
     lxc_template_admin_shell="{{ lxc_template_admin_shell }}"
 {% if lxc_template_admin_system is defined and lxc_template_admin_system %}
@@ -100,8 +101,12 @@ EOF
     lxc_template_admin_home="{{ lxc_template_admin_home }}"
 {% endif %}
 
-    # Create admin system group
-    chroot $rootfs getent group ${lxc_template_admin_group} || chroot $rootfs groupadd --system ${lxc_template_admin_group}
+    # Create required system groups if not present
+    if [ ${{ '{' }}#lxc_template_admin_groups[@]} -ge 0 ] ; then
+        for system_group in ${lxc_template_admin_groups[@]} ; do
+            chroot $rootfs getent group ${system_group} > /dev/null || chroot $rootfs groupadd --system ${system_group}
+        done
+    fi
 
 {% if lxc_template_admin_sudo is defined and lxc_template_admin_sudo %}
     # Configure admin group in sudo
@@ -111,10 +116,15 @@ EOF
 {% endif %}
     # Create administrator account
 {% if lxc_template_admin_system is defined and lxc_template_admin_system %}
-    chroot $rootfs getent passwd ${lxc_template_admin_name} || chroot $rootfs useradd --system --user-group --groups ${lxc_template_admin_group} --create-home --home ${lxc_template_admin_home} --comment "${lxc_template_admin_comment}" --shell ${lxc_template_admin_shell} ${lxc_template_admin_name}
+    chroot $rootfs getent passwd ${lxc_template_admin_name} || chroot $rootfs useradd --system --user-group --groups ${lxc_template_admin_groups_useradd} --create-home --home ${lxc_template_admin_home} --comment "${lxc_template_admin_comment}" --shell ${lxc_template_admin_shell} ${lxc_template_admin_name}
 {% else %}
     chroot $rootfs getent passwd ${lxc_template_admin_name} || chroot $rootfs adduser --disabled-password --home ${lxc_template_admin_home} --gecos "${lxc_template_admin_comment}" --shell ${lxc_template_admin_shell} ${lxc_template_admin_name}
-    chroot $rootfs adduser ${lxc_template_admin_name} ${lxc_template_admin_group}
+
+    if [ ${{ '{' }}#lxc_template_admin_groups[@]} -ge 0 ] ; then
+        for system_group in ${lxc_template_admin_groups[@]} ; do
+            chroot $rootfs adduser ${lxc_template_admin_name} ${system_group}
+        done
+    fi
 {% endif %}
 
 {% endif %}

--- a/templates/usr/share/lxc/templates/lxc-debops.j2
+++ b/templates/usr/share/lxc/templates/lxc-debops.j2
@@ -100,6 +100,9 @@ EOF
 {% else %}
     lxc_template_admin_home="{{ lxc_template_admin_home }}"
 {% endif %}
+{% if lxc_template_sudo is defined and lxc_template_sudo %}
+    lxc_template_sudo_group="{{ lxc_template_sudo_group }}"
+{% endif %}
 
     # Create required system groups if not present
     if [ ${{ '{' }}#lxc_template_admin_groups[@]} -ge 0 ] ; then
@@ -108,10 +111,10 @@ EOF
         done
     fi
 
-{% if lxc_template_admin_sudo is defined and lxc_template_admin_sudo %}
+{% if lxc_template_sudo is defined and lxc_template_sudo %}
     # Configure admin group in sudo
-    echo "%${lxc_template_admin_group} ALL = (ALL:ALL) NOPASSWD: SETENV: ALL" > $rootfs/etc/sudoers.d/${lxc_template_admin_group}
-    chroot $rootfs chmod 0440 /etc/sudoers.d/${lxc_template_admin_group}
+    echo "%${lxc_template_sudo_group} ALL = (ALL:ALL) NOPASSWD: SETENV: ALL" > $rootfs/etc/sudoers.d/${lxc_template_sudo_group}
+    chroot $rootfs chmod 0440 /etc/sudoers.d/${lxc_template_sudo_group}
 
 {% endif %}
     # Create administrator account

--- a/templates/usr/share/lxc/templates/lxc-debops.j2
+++ b/templates/usr/share/lxc/templates/lxc-debops.j2
@@ -36,6 +36,11 @@ done
 export PATH=$PATH:/usr/sbin:/usr/bin:/sbin:/bin
 
 MIRROR=${MIRROR:-{{ lxc_template_debootstrap_mirror }}}
+{% if ansible_distribution in [ 'Debian' ] %}
+DEFAULT_RELEASE="{{ lxc_template_debootstrap_release }}"
+{% else %}
+DEFAULT_RELEASE="stable"
+{% endif %}
 LOCALSTATEDIR="/var"
 LXC_TEMPLATE_CONFIG="/usr/share/lxc/config"
 
@@ -58,7 +63,7 @@ EOF
     # creation
 
     # Add Security repository to sources.list
-    echo "deb http://security.debian.org/ stable/updates main" >> $rootfs/etc/apt/sources.list
+    echo "deb http://security.debian.org/ ${DEFAULT_RELEASE}/updates main" >> $rootfs/etc/apt/sources.list
 
     # Update APT cache
     chroot $rootfs apt-get update
@@ -515,7 +520,7 @@ usage()
 {
     cat <<EOF
 $1 -h|--help -p|--path=<path> [-a|--arch] [-r|--release=<release>] [-c|--clean]
-release: the debian release (e.g. wheezy): defaults to current stable
+release: the debian release (e.g. wheezy): defaults to host release
 arch: the container architecture (e.g. amd64): defaults to host arch
 EOF
     return 0
@@ -602,7 +607,7 @@ if [ "$(id -u)" != "0" ]; then
     exit 1
 fi
 
-current_release=`wget ${MIRROR}/dists/stable/Release -O - 2> /dev/null | head |awk '/^Codename: (.*)$/ { print $2; }'`
+current_release=`wget ${MIRROR}/dists/${DEFAULT_RELEASE}/Release -O - 2> /dev/null | head |awk '/^Codename: (.*)$/ { print $2; }'`
 release=${release:-${current_release}}
 valid_releases=('squeeze' 'wheezy' 'jessie' 'sid')
 if [[ ! "${valid_releases[*]}" =~ (^|[^[:alpha:]])$release([^[:alpha:]]|$) ]]; then


### PR DESCRIPTION
-  Admin account can now be enabled or disabled using separate
  `lxc_template_admin` variable. By default, a system account will be created
  (with UID < 1000) with home in `/var/local/` directory to avoid clashes
  with `/home` directories. You can also specify default shell.

- Switch from creation of 1 system group to a list of system groups that are
  created if not present. Administrator account will be added to all specified
  system groups.

- Modify `sudo` configuration to specify the name of the group that is
  configured to have passwordless access to all commands. By default first
  group specified in `lxc_template_admin_groups` will be granted full access.