### PR TITLE
Set admin account home dir group and permissions

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -31,3 +31,7 @@ v0.1.0
   group specified in ``lxc_template_admin_groups`` will be granted full access.
   [drybjed]
 
+- Add variables to configure administrator account home directory group and
+  permissions. By default, home directory will be owned by ``admins`` group
+  with ``0750`` permissions. [drybjed]
+

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -62,6 +62,12 @@ lxc_template_admin_home: '{{ "/home/" + lxc_template_admin_name }}'
 # Home directory for administrator account (system)
 lxc_template_admin_system_home: '{{ ansible_local.root.home + "/" + lxc_template_admin_name }}'
 
+# Specify administrator account home directory group
+lxc_template_admin_home_group: '{{ lxc_template_admin_groups[0] }}'
+
+# Specify permissions for administrator account home directory
+lxc_template_admin_home_mode: '0750'
+
 # GECOS comment which will be set on the admin account
 lxc_template_admin_comment: 'System Administrator'
 

--- a/templates/usr/share/lxc/templates/lxc-debops.j2
+++ b/templates/usr/share/lxc/templates/lxc-debops.j2
@@ -100,6 +100,9 @@ EOF
 {% else %}
     lxc_template_admin_home="{{ lxc_template_admin_home }}"
 {% endif %}
+    lxc_template_admin_home_group="{{ lxc_template_admin_home_group }}"
+    lxc_template_admin_home_mode="{{ lxc_template_admin_home_mode }}"
+
 {% if lxc_template_sudo is defined and lxc_template_sudo %}
     lxc_template_sudo_group="{{ lxc_template_sudo_group }}"
 {% endif %}
@@ -120,8 +123,12 @@ EOF
     # Create administrator account
 {% if lxc_template_admin_system is defined and lxc_template_admin_system %}
     chroot $rootfs getent passwd ${lxc_template_admin_name} || chroot $rootfs useradd --system --user-group --groups ${lxc_template_admin_groups_useradd} --create-home --home ${lxc_template_admin_home} --comment "${lxc_template_admin_comment}" --shell ${lxc_template_admin_shell} ${lxc_template_admin_name}
+    chroot $rootfs chgrp ${lxc_template_admin_home_group} ${lxc_template_admin_home}
+    chroot $rootfs chmod ${lxc_template_admin_home_mode} ${lxc_template_admin_home}
 {% else %}
     chroot $rootfs getent passwd ${lxc_template_admin_name} || chroot $rootfs adduser --disabled-password --home ${lxc_template_admin_home} --gecos "${lxc_template_admin_comment}" --shell ${lxc_template_admin_shell} ${lxc_template_admin_name}
+    chroot $rootfs chgrp ${lxc_template_admin_home_group} ${lxc_template_admin_home}
+    chroot $rootfs chmod ${lxc_template_admin_home_mode} ${lxc_template_admin_home}
 
     if [ ${{ '{' }}#lxc_template_admin_groups[@]} -ge 0 ] ; then
         for system_group in ${lxc_template_admin_groups[@]} ; do


### PR DESCRIPTION
Add variables to configure administrator account home directory group
and permissions. By default, home directory will be owned by 'admins'
group with `0750' permissions.