### PR TITLE
Add support for debian testing/unstable.

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,7 +8,7 @@
     name: '{{ item }}'
     state: 'present'
     install_recommends: False
-  with_items: lxc_distribution_packages[ansible_distribution + '_' + (ansible_distribution_release.split("/")[0])]
+  with_items: lxc_distribution_packages[ansible_distribution]
 
 - name: Check available LXC package version
   shell: lxc-create --version

--- a/templates/etc/lxc/lxc.conf.j2
+++ b/templates/etc/lxc/lxc.conf.j2
@@ -6,7 +6,7 @@
 lxc.lxcpath = {{ lxc_root_path }}
 
 {% if (ansible_distribution == 'Debian' and
-       ansible_distribution_release == 'jessie') %}
+       ansible_distribution_release != 'wheezy') %}
 # Use all cgroup controllers in the containers
 lxc.cgroup.use = @all
 {% endif %}

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -2,10 +2,8 @@
 
 # List of packages to install on different distributions
 lxc_distribution_packages:
-  Debian_wheezy:  [ 'debootstrap', 'python3', 'lxc', 'init-system-helpers' ]
-  Debian_jessie:  [ 'debootstrap', 'python3', 'lxc', 'init-system-helpers' ]
-  Ubuntu_precise: [ 'debootstrap', 'python3', 'lxc', 'lxc-templates', 'libcgmanager0' ]
-  Ubuntu_trusty:  [ 'debootstrap', 'python3', 'lxc', 'lxc-templates', 'libcgmanager0' ]
+  Debian:  [ 'debootstrap', 'python3', 'lxc', 'init-system-helpers' ]
+  Ubuntu:  [ 'debootstrap', 'python3', 'lxc', 'lxc-templates', 'libcgmanager0' ]
 
 # Notification message about new of updated LXC kernel
 lxc_kernel_mail_subject: 'LXC kernel update on {{ ansible_fqdn }}'


### PR DESCRIPTION
`lxc_distribution_packages` can be simplified, since both supported debian and ubuntu versions have 
the same values respectively
the lxc fix from #16 is also necessary in testing/unstable, but not in wheezy