### PR TITLE
Test for stdout_lines in stop task

### DIFF
--- a/tasks/manage_containers.yml
+++ b/tasks/manage_containers.yml
@@ -78,7 +78,7 @@
   when: ((item.0.name is defined and item.0.name) and
          (item.1.item.name is defined and item.0.name == item.1.item.name) and
          (item.0.state|d("present") in ['stopped', 'absent']) and
-         (item.1.stdout_lines[0] == 'RUNNING'))
+         (item.1.stdout_lines  and  item.1.stdout_lines[0] == 'RUNNING'))
 
 - name: Destroy LXC containers when requested
   command: lxc-destroy -n {{ item.name }}


### PR DESCRIPTION
The task "Stop LXC containers when requested" assumes that
item.1.stdout_lines[0] exists.  If, however, the container does not
exist, e.g. when lxc_register_container_status.results is more like

            "stderr": "foobuuntu doesn't exist",
            "stdout": "",
            "stdout_lines": [],

then stdout_lines is the empty list.  It thus does not have a first
element.  Ansible then complains:

TASK [debops.lxc : Stop LXC containers when requested]
*************************
task path: ~/.local/share/debops/debops-
playbooks/roles/debops.lxc/tasks/manage_containers.yml:78
fatal: [testbox]: FAILED! => {"failed": true, "msg": "The conditional
check '((item.0.name is defined and item.0.name) and (item.1.item.name
is defined and item.0.name == item.1.item.name) and
(item.0.state|d(\"present\") in ['stopped', 'absent']) and
(item.1.stdout_lines[0] == 'RUNNING'))' failed. The error was: error
while evaluating conditional (((item.0.name is defined and item.0.name)
and (item.1.item.name is defined and item.0.name == item.1.item.name)
and (item.0.state|d(\"present\") in ['stopped', 'absent']) and
(item.1.stdout_lines[0] == 'RUNNING'))): list object has no element
0\n\nThe error appears to have been in '~/.local/share/debops/debops-
playbooks/roles/debops.lxc/tasks/manage_containers.yml': line 78, column
3, but may\nbe elsewhere in the file depending on the exact syntax
problem.\n\nThe offending line appears to be:\n\n\n- name: Stop LXC
containers when requested\n  ^ here\n"}